### PR TITLE
Integrate official G1 protocol features

### DIFF
--- a/G1 Connect/Constants.swift
+++ b/G1 Connect/Constants.swift
@@ -43,6 +43,10 @@ struct Constants {
         static let imagePacket: UInt8 = 0x15
         static let imageEnd: [UInt8] = [0x20, 0x0d, 0x0e]
         static let imageCRC: UInt8 = 0x16
+
+        // Connection maintenance and exit
+        static let heartbeat: UInt8 = 0x25
+        static let exitFeature: UInt8 = 0x18
     }
     
     // MARK: - G1 Display Specifications (Official)

--- a/G1 Connect/README.md
+++ b/G1 Connect/README.md
@@ -105,6 +105,18 @@ Die App verwendet eine moderne SwiftUI-Architektur mit folgenden Komponenten:
 - **SettingsManager.swift**: ObservableObject für Einstellungsverwaltung
 - **SpeechRecognizer.swift**: Spracherkennung für "Hey, Lily"
 
+## Nutzung der offiziellen Demo-App
+
+Die Implementierung orientiert sich an der von Even Realities bereitgestellten
+[EvenDemoApp](https://github.com/even-realities/EvenDemoApp). Einige Protokoll-
+Features wie das periodische Heartbeat-Signal (Befehl `0x25`) und das
+Verlassen aller Funktionen über `0x18` wurden übernommen. Die App sendet nun
+automatisch alle acht Sekunden ein Heartbeat-Paket, sobald beide Brillenarme
+verbunden sind. Bei einer Trennung wird das Heartbeat beendet.
+Das Kommando zum Verlassen kann zudem über die Methode
+`exitToDashboard()` im `BluetoothManager` ausgelöst werden.
+
+
 ## Fehlerbehebung
 
 ### Bluetooth-Verbindungsprobleme


### PR DESCRIPTION
## Summary
- implement heartbeat and exit commands for G1 glasses
- maintain heartbeat when both devices are connected
- expose `exitToDashboard()` method
- document new features with reference to EvenDemoApp

## Testing
- `swiftc -parse 'G1 Connect/BluetoothManager.swift'`
- `swiftc -parse 'G1 Connect/Constants.swift'`

------
https://chatgpt.com/codex/tasks/task_e_68405f654f8c8330a81a4b02865f7f52